### PR TITLE
Cache enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,7 +527,7 @@ Refer to the [Changelog](CHANGELOG.md) for a full history of the project.
 
 The following support channels are available at your fingertips:
 
-- [Chat](https://slack.rinvex.com)
+- [Chat](https://gitter.im/rinvex/chat)
 - [Email](mailto:help@rinvex.com)
 - [Twitter](https://twitter.com/rinvex)
 

--- a/src/Contracts/RepositoryContract.php
+++ b/src/Contracts/RepositoryContract.php
@@ -71,6 +71,13 @@ interface RepositoryContract
     public function getCacheLifetime();
 
     /**
+     * Convenience method. Alias to setCacheLifetime(0).
+     *
+     * @return $this
+     */
+    public function skipCache();
+
+    /**
      * Set the repository cache driver.
      *
      * @param string $cacheDriver

--- a/src/Repositories/BaseRepository.php
+++ b/src/Repositories/BaseRepository.php
@@ -59,7 +59,7 @@ abstract class BaseRepository implements RepositoryContract
     /**
      * The repository cache lifetime.
      *
-     * @var int|float
+     * @var float|int
      */
     protected $cacheLifetime;
 

--- a/src/Repositories/BaseRepository.php
+++ b/src/Repositories/BaseRepository.php
@@ -59,7 +59,7 @@ abstract class BaseRepository implements RepositoryContract
     /**
      * The repository cache lifetime.
      *
-     * @var int
+     * @var int|float
      */
     protected $cacheLifetime;
 
@@ -184,6 +184,18 @@ abstract class BaseRepository implements RepositoryContract
         return ! is_null($this->cacheLifetime)
             ? $this->cacheLifetime
             : $this->getContainer('config')->get('rinvex.repository.cache.lifetime');
+    }
+
+    /**
+     * Convenience method. Alias to setCacheLifetime(0).
+     *
+     * @return $this
+     */
+    public function skipCache()
+    {
+        $this->setCacheLifetime(0);
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
From Laravel 5.3 onwards, one will be able to cache data in minute fractions. A cache lifetime of 0.5 equals to 30 seconds.
Added a convenience method to skip cache for a specific repository query.