### PR TITLE
Criteria implementation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,12 +46,21 @@
         "illuminate/container": "5.1.*|5.2.*|5.3.*",
         "illuminate/contracts": "5.1.*|5.2.*|5.3.*"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~5.0",
+        "illuminate/config": "5.1.*|5.2.*|5.3.*"
+    },
     "suggest": {
         "illuminate/pagination": "Required to paginate the result set."
     },
     "autoload": {
         "psr-4": {
             "Rinvex\\Repository\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Rinvex\\Tests\\": "tests"
         }
     },
     "extra": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,1995 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "hash": "1cff06e97e69ec3d970d3f682a42fe6e",
+    "content-hash": "005417d8e40acb760975a5859947791a",
+    "packages": [
+        {
+            "name": "doctrine/inflector",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/inflector.git",
+                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/inflector/zipball/90b2128806bfde671b6952ab8bea493942c1fdae",
+                "reference": "90b2128806bfde671b6952ab8bea493942c1fdae",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Doctrine\\Common\\Inflector\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Common String Manipulations with regard to casing and singular/plural rules.",
+            "homepage": "http://www.doctrine-project.org",
+            "keywords": [
+                "inflection",
+                "pluralize",
+                "singularize",
+                "string"
+            ],
+            "time": "2015-11-06 14:35:42"
+        },
+        {
+            "name": "illuminate/container",
+            "version": "v5.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/container.git",
+                "reference": "360f4900dbaa7e76ecfbb58e0ad4b244a90edfe3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/container/zipball/360f4900dbaa7e76ecfbb58e0ad4b244a90edfe3",
+                "reference": "360f4900dbaa7e76ecfbb58e0ad4b244a90edfe3",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "5.3.*",
+                "php": ">=5.6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Container\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Container package.",
+            "homepage": "https://laravel.com",
+            "time": "2016-08-05 14:48:10"
+        },
+        {
+            "name": "illuminate/contracts",
+            "version": "v5.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/contracts.git",
+                "reference": "f766fc0452d82d545b866a8ad5860b20ccd50763"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/f766fc0452d82d545b866a8ad5860b20ccd50763",
+                "reference": "f766fc0452d82d545b866a8ad5860b20ccd50763",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Contracts\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Contracts package.",
+            "homepage": "https://laravel.com",
+            "time": "2016-08-21 12:37:00"
+        },
+        {
+            "name": "illuminate/database",
+            "version": "v5.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/database.git",
+                "reference": "048a65ba4a7ed250e16c82b6bb323daf38410050"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/database/zipball/048a65ba4a7ed250e16c82b6bb323daf38410050",
+                "reference": "048a65ba4a7ed250e16c82b6bb323daf38410050",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/container": "5.3.*",
+                "illuminate/contracts": "5.3.*",
+                "illuminate/support": "5.3.*",
+                "nesbot/carbon": "~1.20",
+                "php": ">=5.6.4"
+            },
+            "suggest": {
+                "doctrine/dbal": "Required to rename columns and drop SQLite columns (~2.4).",
+                "fzaninotto/faker": "Required to use the eloquent factory builder (~1.4).",
+                "illuminate/console": "Required to use the database commands (5.3.*).",
+                "illuminate/events": "Required to use the observers with Eloquent (5.3.*).",
+                "illuminate/filesystem": "Required to use the migrations (5.3.*).",
+                "illuminate/pagination": "Required to paginate the result set (5.3.*)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Database\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Database package.",
+            "homepage": "https://laravel.com",
+            "keywords": [
+                "database",
+                "laravel",
+                "orm",
+                "sql"
+            ],
+            "time": "2016-08-25 15:46:46"
+        },
+        {
+            "name": "illuminate/events",
+            "version": "v5.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/events.git",
+                "reference": "cb29124d4eaba8a60bad40e95e3d8b199d040d77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/events/zipball/cb29124d4eaba8a60bad40e95e3d8b199d040d77",
+                "reference": "cb29124d4eaba8a60bad40e95e3d8b199d040d77",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/container": "5.3.*",
+                "illuminate/contracts": "5.3.*",
+                "illuminate/support": "5.3.*",
+                "php": ">=5.6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Events\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Events package.",
+            "homepage": "https://laravel.com",
+            "time": "2016-08-12 14:24:30"
+        },
+        {
+            "name": "illuminate/support",
+            "version": "v5.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/support.git",
+                "reference": "1b4f32dfa799dd8d0e0d11e0aaaf677e2829d6e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/1b4f32dfa799dd8d0e0d11e0aaaf677e2829d6e8",
+                "reference": "1b4f32dfa799dd8d0e0d11e0aaaf677e2829d6e8",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/inflector": "~1.0",
+                "ext-mbstring": "*",
+                "illuminate/contracts": "5.3.*",
+                "paragonie/random_compat": "~1.4|~2.0",
+                "php": ">=5.6.4"
+            },
+            "replace": {
+                "tightenco/collect": "self.version"
+            },
+            "suggest": {
+                "illuminate/filesystem": "Required to use the composer class (5.2.*).",
+                "symfony/process": "Required to use the composer class (3.1.*).",
+                "symfony/var-dumper": "Required to use the dd function (3.1.*)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Support\\": ""
+                },
+                "files": [
+                    "helpers.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Support package.",
+            "homepage": "https://laravel.com",
+            "time": "2016-08-26 17:26:49"
+        },
+        {
+            "name": "nesbot/carbon",
+            "version": "1.21.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/briannesbitt/Carbon.git",
+                "reference": "7b08ec6f75791e130012f206e3f7b0e76e18e3d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/briannesbitt/Carbon/zipball/7b08ec6f75791e130012f206e3f7b0e76e18e3d7",
+                "reference": "7b08ec6f75791e130012f206e3f7b0e76e18e3d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "symfony/translation": "~2.6|~3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0|~5.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Carbon\\": "src/Carbon/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brian Nesbitt",
+                    "email": "brian@nesbot.com",
+                    "homepage": "http://nesbot.com"
+                }
+            ],
+            "description": "A simple API extension for DateTime.",
+            "homepage": "http://carbon.nesbot.com",
+            "keywords": [
+                "date",
+                "datetime",
+                "time"
+            ],
+            "time": "2015-11-04 20:07:17"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "088c04e2f261c33bed6ca5245491cfca69195ccf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/088c04e2f261c33bed6ca5245491cfca69195ccf",
+                "reference": "088c04e2f261c33bed6ca5245491cfca69195ccf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/random.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2016-04-03 06:00:07"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "dff51f72b0706335131b00a7f49606168c582594"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/dff51f72b0706335131b00a7f49606168c582594",
+                "reference": "dff51f72b0706335131b00a7f49606168c582594",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2016-05-18 14:26:46"
+        },
+        {
+            "name": "symfony/translation",
+            "version": "v3.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/translation.git",
+                "reference": "a35edc277513c9bc0f063ca174c36b346f974528"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/a35edc277513c9bc0f063ca174c36b346f974528",
+                "reference": "a35edc277513c9bc0f063ca174c36b346f974528",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "conflict": {
+                "symfony/config": "<2.8"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/config": "~2.8|~3.0",
+                "symfony/intl": "~2.8|~3.0",
+                "symfony/yaml": "~2.8|~3.0"
+            },
+            "suggest": {
+                "psr/log": "To use logging capability in translator",
+                "symfony/config": "",
+                "symfony/yaml": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Translation\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Translation Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-08-05 08:37:39"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3,<8.0-DEV"
+            },
+            "require-dev": {
+                "athletic/athletic": "~0.1.8",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpunit/phpunit": "~4.0",
+                "squizlabs/php_codesniffer": "~2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "http://ocramius.github.com/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://github.com/doctrine/instantiator",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "time": "2015-06-14 21:17:01"
+        },
+        {
+            "name": "illuminate/config",
+            "version": "v5.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/config.git",
+                "reference": "26df89fa2999754e882890e642b67c6521432057"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/config/zipball/26df89fa2999754e882890e642b67c6521432057",
+                "reference": "26df89fa2999754e882890e642b67c6521432057",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "5.3.*",
+                "illuminate/filesystem": "5.3.*",
+                "illuminate/support": "5.3.*",
+                "php": ">=5.6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Config\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Config package.",
+            "homepage": "https://laravel.com",
+            "time": "2016-08-05 14:48:10"
+        },
+        {
+            "name": "illuminate/filesystem",
+            "version": "v5.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/illuminate/filesystem.git",
+                "reference": "72da79358499a38b437ff4b0e42f909660555298"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/72da79358499a38b437ff4b0e42f909660555298",
+                "reference": "72da79358499a38b437ff4b0e42f909660555298",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/contracts": "5.3.*",
+                "illuminate/support": "5.3.*",
+                "php": ">=5.6.4",
+                "symfony/finder": "3.1.*"
+            },
+            "suggest": {
+                "league/flysystem": "Required to use the Flysystem local and FTP drivers (~1.0).",
+                "league/flysystem-aws-s3-v3": "Required to use the Flysystem S3 driver (~1.0).",
+                "league/flysystem-rackspace": "Required to use the Flysystem Rackspace driver (~1.0)."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Illuminate\\Filesystem\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "The Illuminate Filesystem package.",
+            "homepage": "https://laravel.com",
+            "time": "2016-08-22 03:02:14"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "da8529775f14f4fdae33f916eb0cf65f6afbddbc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/da8529775f14f4fdae33f916eb0cf65f6afbddbc",
+                "reference": "da8529775f14f4fdae33f916eb0cf65f6afbddbc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "doctrine/collections": "1.*",
+                "phpunit/phpunit": "~4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "homepage": "https://github.com/myclabs/DeepCopy",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2016-09-06 16:07:05"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2015-12-27 11:43:31"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "3.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/9270140b940ff02e58ec577c237274e92cd40cdd",
+                "reference": "9270140b940ff02e58ec577c237274e92cd40cdd",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/type-resolver": "^0.2.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^4.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2016-06-10 09:48:41"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "reference": "b39c7a5b194f9ed7bd0dd345c751007a41862443",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2016-06-10 07:14:17"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "58a8137754bc24b25740d4281399a4a3596058e0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/58a8137754bc24b25740d4281399a4a3596058e0",
+                "reference": "58a8137754bc24b25740d4281399a4a3596058e0",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "sebastian/comparator": "^1.1",
+                "sebastian/recursion-context": "^1.0"
+            },
+            "require-dev": {
+                "phpspec/phpspec": "^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Prophecy\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "email": "marcello.duarte@gmail.com"
+                }
+            ],
+            "description": "Highly opinionated mocking framework for PHP 5.3+",
+            "homepage": "https://github.com/phpspec/prophecy",
+            "keywords": [
+                "Double",
+                "Dummy",
+                "fake",
+                "mock",
+                "spy",
+                "stub"
+            ],
+            "time": "2016-06-07 08:13:47"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "5f3f7e736d6319d5f1fc402aff8b026da26709a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/5f3f7e736d6319d5f1fc402aff8b026da26709a3",
+                "reference": "5f3f7e736d6319d5f1fc402aff8b026da26709a3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-file-iterator": "~1.3",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-token-stream": "^1.4.2",
+                "sebastian/code-unit-reverse-lookup": "~1.0",
+                "sebastian/environment": "^1.3.2 || ^2.0",
+                "sebastian/version": "~1.0|~2.0"
+            },
+            "require-dev": {
+                "ext-xdebug": ">=2.1.4",
+                "phpunit/phpunit": "^5.4"
+            },
+            "suggest": {
+                "ext-dom": "*",
+                "ext-xdebug": ">=2.4.0",
+                "ext-xmlwriter": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "time": "2016-07-26 14:39:29"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "time": "2015-06-21 13:08:43"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "reference": "31f8b717e51d9a2afca6c9f046f5d69fc27c8686",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "time": "2015-06-21 13:50:34"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "reference": "38e9124049cf1a164f1e4537caf19c99bf1eb260",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4|~5"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "time": "2016-05-12 18:03:57"
+        },
+        {
+            "name": "phpunit/php-token-stream",
+            "version": "1.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-token-stream.git",
+                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Wrapper around PHP's tokenizer extension.",
+            "homepage": "https://github.com/sebastianbergmann/php-token-stream/",
+            "keywords": [
+                "tokenizer"
+            ],
+            "time": "2015-09-15 10:49:45"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "5.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "3e6e88e56c912133de6e99b87728cca7ed70c5f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3e6e88e56c912133de6e99b87728cca7ed70c5f5",
+                "reference": "3e6e88e56c912133de6e99b87728cca7ed70c5f5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "myclabs/deep-copy": "~1.3",
+                "php": "^5.6 || ^7.0",
+                "phpspec/prophecy": "^1.3.1",
+                "phpunit/php-code-coverage": "^4.0.1",
+                "phpunit/php-file-iterator": "~1.4",
+                "phpunit/php-text-template": "~1.2",
+                "phpunit/php-timer": "^1.0.6",
+                "phpunit/phpunit-mock-objects": "^3.2",
+                "sebastian/comparator": "~1.1",
+                "sebastian/diff": "~1.2",
+                "sebastian/environment": "^1.3 || ^2.0",
+                "sebastian/exporter": "~1.2",
+                "sebastian/global-state": "~1.0",
+                "sebastian/object-enumerator": "~1.0",
+                "sebastian/resource-operations": "~1.0",
+                "sebastian/version": "~1.0|~2.0",
+                "symfony/yaml": "~2.1|~3.0"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2"
+            },
+            "suggest": {
+                "phpunit/php-invoker": "~1.1"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.5.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "time": "2016-08-26 07:11:44"
+        },
+        {
+            "name": "phpunit/phpunit-mock-objects",
+            "version": "3.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
+                "reference": "546898a2c0c356ef2891b39dd7d07f5d82c8ed0a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/546898a2c0c356ef2891b39dd7d07f5d82c8ed0a",
+                "reference": "546898a2c0c356ef2891b39dd7d07f5d82c8ed0a",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.2",
+                "php": "^5.6 || ^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^1.2"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.4"
+            },
+            "suggest": {
+                "ext-soap": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sb@sebastian-bergmann.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Mock Object library for PHPUnit",
+            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
+            "keywords": [
+                "mock",
+                "xunit"
+            ],
+            "time": "2016-09-06 16:07:45"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
+                "reference": "c36f5e7cfce482fde5bf8d10d41a53591e0198fe",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2016-02-13 06:45:14"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
+                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/diff": "~1.2",
+                "sebastian/exporter": "~1.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "http://www.github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "time": "2015-07-26 15:48:44"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff"
+            ],
+            "time": "2015-12-08 07:14:41"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "1.3.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "reference": "be2c607e43ce4c89ecd60e75c6a85c126e754aea",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "time": "2016-08-18 05:49:44"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "reference": "42c4c2eec485ee3e159ec9884f95b431287edde4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3",
+                "sebastian/recursion-context": "~1.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "time": "2016-06-17 09:04:28"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.2"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "time": "2015-10-12 03:26:01"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/d4ca2fb70344987502567bc50081c03e6192fb26",
+                "reference": "d4ca2fb70344987502567bc50081c03e6192fb26",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "sebastian/recursion-context": "~1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2016-01-28 13:25:10"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "time": "2015-11-11 19:50:13"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28 20:34:47"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "reference": "c829badbd8fdf16a0bad8aa7fa7971c029f1b9c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "time": "2016-02-04 12:56:52"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v3.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "e568ef1784f447a0e54dcb6f6de30b9747b0f577"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/e568ef1784f447a0e54dcb6f6de30b9747b0f577",
+                "reference": "e568ef1784f447a0e54dcb6f6de30b9747b0f577",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Finder Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-08-26 12:04:02"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v3.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "f291ed25eb1435bddbe8a96caaef16469c2a092d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/f291ed25eb1435bddbe8a96caaef16469c2a092d",
+                "reference": "f291ed25eb1435bddbe8a96caaef16469c2a092d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-09-02 02:12:52"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/bb2d123231c095735130cc8f6d31385a44c7b308",
+                "reference": "bb2d123231c095735130cc8f6d31385a44c7b308",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.3|^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2016-08-09 15:02:57"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": [],
+    "prefer-stable": true,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.5.9"
+    },
+    "platform-dev": []
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         syntaxCheck="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="EloquentRepository Test Suite">
+            <file>tests/AbstractEloquentTests.php</file>
+            <file>tests/EloquentRepositoryTests.php</file>
+        </testsuite>
+
+        <testsuite name="EloquentRepositoryCriteria Test Suite">
+            <directory suffix="Tests.php">tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Contracts/CriterionContract.php
+++ b/src/Contracts/CriterionContract.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * NOTICE OF LICENSE
+ *
+ * Part of the Rinvex Repository Package.
+ *
+ * This source file is subject to The MIT License (MIT)
+ * that is bundled with this package in the LICENSE file.
+ *
+ * Package: Rinvex Repository Package
+ * License: The MIT License (MIT)
+ * Link:    https://rinvex.com
+ */
+
+namespace Rinvex\Repository\Contracts;
+
+interface CriterionContract
+{
+    /**
+     * Apply current criterion to the given query and return query.
+     *
+     * @param mixed              $query
+     * @param RepositoryContract $repository
+     *
+     * @return mixed
+     */
+    public function apply($query, $repository);
+}

--- a/src/Exceptions/CriterionException.php
+++ b/src/Exceptions/CriterionException.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * NOTICE OF LICENSE
+ *
+ * Part of the Rinvex Repository Package.
+ *
+ * This source file is subject to The MIT License (MIT)
+ * that is bundled with this package in the LICENSE file.
+ *
+ * Package: Rinvex Repository Package
+ * License: The MIT License (MIT)
+ * Link:    https://rinvex.com
+ */
+
+namespace Rinvex\Repository\Exceptions;
+
+use Exception;
+use Rinvex\Repository\Contracts\CriterionContract;
+
+class CriterionException extends Exception
+{
+    public static function wrongCriterionType($criterion)
+    {
+        $type  = gettype($criterion);
+        $value = $type === 'object' ? get_class($criterion) : $criterion;
+
+        return new static('Given criterion with type '.$type.' and value '.$value.' is not allowed');
+    }
+
+    public static function classNotImplementContract($criterionClassName)
+    {
+        return new static('Given '.$criterionClassName.' class is not implement '.CriterionContract::class.'contract');
+    }
+
+    public static function wrongArraySignature(array $criterion)
+    {
+        return new static(
+            'Array signature for criterion instantiating must contain only two elements in case of sequential array and one in case of assoc array. '.
+            'Array with length "'.count($criterion).'" given');
+    }
+}

--- a/src/Exceptions/RepositoryException.php
+++ b/src/Exceptions/RepositoryException.php
@@ -19,5 +19,8 @@ use Exception;
 
 class RepositoryException extends Exception
 {
-    //
+    public static function listNotFound($list, $object)
+    {
+        return new static('Given list "'.$list.'" not found in '.get_class($object).' class');
+    }
 }

--- a/src/Repositories/BaseRepository.php
+++ b/src/Repositories/BaseRepository.php
@@ -128,7 +128,7 @@ abstract class BaseRepository implements RepositoryContract, CacheableContract
             return $this->cacheCallback($class, $method, $args, $closure);
         }
 
-        // Cache disabled, just execute qurey & return result
+        // Cache disabled, just execute query & return result
         $result = call_user_func($closure);
 
         // We're done, let's clean up!
@@ -152,6 +152,10 @@ abstract class BaseRepository implements RepositoryContract, CacheableContract
         $this->offset     = null;
         $this->limit      = null;
         $this->orderBy    = [];
+
+        if (method_exists($this, 'flushCriteria')) {
+            $this->flushCriteria();
+        }
 
         return $this;
     }
@@ -213,6 +217,11 @@ abstract class BaseRepository implements RepositoryContract, CacheableContract
             list($attribute, $direction) = $this->orderBy;
 
             $model = $model->orderBy($attribute, $direction);
+        }
+
+        // Apply all criteria to the query
+        if (method_exists($this, 'applyCriteria')) {
+            $model = $this->applyCriteria($model, $this);
         }
 
         return $model;

--- a/src/Traits/Criteriable.php
+++ b/src/Traits/Criteriable.php
@@ -1,0 +1,362 @@
+<?php
+
+namespace Rinvex\Repository\Traits;
+
+use Closure;
+use Rinvex\Repository\Contracts\CriterionContract;
+use Rinvex\Repository\Contracts\RepositoryContract;
+use Rinvex\Repository\Exceptions\CriterionException;
+use Rinvex\Repository\Exceptions\RepositoryException;
+
+trait Criteriable
+{
+    /**
+     * List of repository criteria.
+     *
+     * @var array
+     */
+    protected $criteria = [];
+
+    /**
+     * List of default repository criteria.
+     *
+     * @var array
+     */
+    protected $defaultCriteria = [];
+
+    /**
+     * Skip criteria flag.
+     * If setted to true criteria will not be apply to the query.
+     *
+     * @var bool
+     */
+    protected $skipCriteria = false;
+
+    /**
+     * Skip default criteria flag.
+     * If setted to true default criteria will not be added to the criteria list.
+     *
+     * @var bool
+     */
+    protected $skipDefaultCriteria = false;
+
+    /**
+     * Return name for the criterion.
+     * If as criterion in parameter passed string we assume that is criterion class name.
+     *
+     * @param CriterionContract|Closure|string $criteria
+     *
+     * @return string
+     */
+    public function getCriterionName($criteria)
+    {
+        if ($criteria instanceof Closure) {
+            return spl_object_hash($criteria);
+        }
+
+        return is_object($criteria) ? get_class($criteria) : $criteria;
+    }
+
+    /**
+     * Try to instantiate given criterion class name with this arguments.
+     *
+     * @param $class
+     * @param $arguments
+     *
+     * @throws CriterionException
+     *
+     * @return object
+     */
+    protected function instantiateCriterion($class, $arguments)
+    {
+        $reflection = new \ReflectionClass($class);
+
+        if (! $reflection->implementsInterface(CriterionContract::class)) {
+            throw CriterionException::classNotImplementContract($class);
+        }
+
+        //If arguments is an associative array we can assume their order and parameter existence
+        if (count($arguments) && array_keys($arguments) !== range(0, count($arguments) - 1)) {
+            $parameters = array_column($reflection->getConstructor()->getParameters(), 'name');
+
+            $arguments = array_filter(array_map(function ($parameter) use ($arguments) {
+                return isset($arguments[$parameter]) ? $arguments[$parameter] : null;
+            }, $parameters));
+        }
+
+        return $reflection->newInstanceArgs($arguments);
+    }
+
+    /**
+     * Return class and arguments from passed array criterion.
+     * Extracting class and arguments from array.
+     *
+     * @param array $criterion
+     *
+     * @throws CriterionException
+     *
+     * @return array
+     */
+    protected function extractCriterionClassAndArgs(array $criterion)
+    {
+        if (count($criterion) > 2 || empty($criterion)) {
+            throw CriterionException::wrongArraySignature($criterion);
+        }
+
+        //If an array is assoc we assume that the key is a class and value is an arguments
+        if (array_keys($criterion) !== range(0, count($criterion) - 1)) {
+            $criterion = [array_keys($criterion)[0], array_values($criterion)[0]];
+
+        //If an array is not assoc but count is one, we can assume there is a class without arguments.
+        //Like when a string passed as criterion
+        } elseif (count($criterion) === 1) {
+            array_push($criterion, []);
+        }
+
+        return $criterion;
+    }
+
+    /**
+     * Add criterion to the specific list.
+     * low-level implementation of adding criterion to the list.
+     *
+     * @param Closure|CriterionContract|array|string $criterion
+     * @param string                                 $list
+     *
+     * @throws CriterionException
+     * @throws RepositoryException
+     *
+     * @return $this
+     */
+    protected function addCriterion($criterion, $list)
+    {
+        if (! property_exists($this, $list)) {
+            throw RepositoryException::listNotFound($list, $this);
+        }
+
+        if (! $criterion instanceof Closure &&
+            ! $criterion instanceof CriterionContract &&
+            ! is_string($criterion) &&
+            ! is_array($criterion)
+        ) {
+            throw CriterionException::wrongCriterionType($criterion);
+        }
+
+        //If criterion is a string we will assume it is a class name without arguments
+        //and we need to normalize signature for instantiation try
+        if (is_string($criterion)) {
+            $criterion = [$criterion, []];
+        }
+
+        //If the criterion is an array we will assume it is an array of class name with arguments
+        //and try to instantiate this
+        if (is_array($criterion)) {
+            $criterion = call_user_func_array([$this, 'instantiateCriterion'], $this->extractCriterionClassAndArgs($criterion));
+        }
+
+        $this->$list[$this->getCriterionName($criterion)] = $criterion;
+
+        return $this;
+    }
+
+    /**
+     * Add criteria to the specific list
+     * low-level implementation of adding criteria to the list.
+     *
+     * @param array $criteria
+     * @param $list
+     */
+    protected function addCriteria(array $criteria, $list)
+    {
+        array_walk($criteria, function ($value, $key) use ($list) {
+            $criterion = is_string($key) ? [$key, $value] : $value;
+            $this->addCriterion($criterion, $list);
+        });
+    }
+
+    /**
+     * Push criterion to the criteria list.
+     *
+     * @param CriterionContract|Closure|array|string $criterion
+     *
+     * @return $this
+     */
+    public function pushCriterion($criterion)
+    {
+        $this->addCriterion($criterion, 'criteria');
+
+        return $this;
+    }
+
+    /**
+     * Remove provided criterion from criteria list.
+     *
+     * @param CriterionContract|Closure|string $criterion
+     *
+     * @return $this
+     */
+    public function removeCriterion($criterion)
+    {
+        unset($this->criteria[$this->getCriterionName($criterion)]);
+
+        return $this;
+    }
+
+    /**
+     * Remove provided criteria from criteria list.
+     *
+     * @param array $criteria
+     *
+     * @return RepositoryContract
+     */
+    public function removeCriteria(array $criteria)
+    {
+        array_walk($criteria, function ($criterion) {
+            $this->removeCriterion($criterion);
+        });
+
+        return $this;
+    }
+
+    /**
+     * Push array of criteria to the criteria list.
+     *
+     * @param array $criteria
+     *
+     * @return $this
+     */
+    public function pushCriteria(array $criteria)
+    {
+        $this->addCriteria($criteria, 'criteria');
+
+        return $this;
+    }
+
+    /**
+     * Flush criteria list.
+     * We can flush criteria only when they is not skipped.
+     *
+     * @return $this
+     */
+    public function flushCriteria()
+    {
+        if (! $this->skipCriteria) {
+            $this->criteria = [];
+        }
+
+        return $this;
+    }
+
+    /**
+     * Set default criteria list.
+     *
+     * @param array $criteria
+     *
+     * @return $this
+     */
+    public function setDefaultCriteria(array $criteria)
+    {
+        $this->addCriteria($criteria, 'defaultCriteria');
+
+        return $this;
+    }
+
+    /**
+     * Return default criteria list.
+     *
+     * @return array
+     */
+    public function getDefaultCriteria()
+    {
+        return $this->defaultCriteria;
+    }
+
+    /**
+     * Return current list of criteria.
+     *
+     * @return array
+     */
+    public function getCriteria()
+    {
+        if ($this->skipCriteria) {
+            return [];
+        }
+
+        return $this->skipDefaultCriteria ? $this->criteria : array_merge($this->getDefaultCriteria(), $this->criteria);
+    }
+
+    /**
+     * Set skipCriteria flag.
+     *
+     * @param bool|true $flag
+     *
+     * @return $this
+     */
+    public function skipCriteria($flag = true)
+    {
+        $this->skipCriteria = $flag;
+
+        return $this;
+    }
+
+    /**
+     * Set skipDefaultCriteria flag.
+     *
+     * @param bool|true $flag
+     *
+     * @return $this
+     */
+    public function skipDefaultCriteria($flag = true)
+    {
+        $this->skipDefaultCriteria = $flag;
+
+        return $this;
+    }
+
+    /**
+     * Check if a given criterion name now in the criteria list.
+     *
+     * @param CriterionContract|Closure|string $criterion
+     *
+     * @return bool
+     */
+    public function hasCriterion($criterion)
+    {
+        return isset($this->getCriteria()[$this->getCriterionName($criterion)]);
+    }
+
+    /**
+     * Return criterion object or closure from criteria list by name.
+     *
+     * @param $criterion
+     *
+     * @return CriterionContract|Closure|null
+     */
+    public function getCriterion($criterion)
+    {
+        if ($this->hasCriterion($criterion)) {
+            return $this->getCriteria()[$this->getCriterionName($criterion)];
+        }
+    }
+
+    /**
+     * Apply criteria list to the given query.
+     *
+     * @param $query
+     * @param $repository
+     *
+     * @return mixed
+     */
+    public function applyCriteria($query, $repository)
+    {
+        foreach ($this->getCriteria() as $criterion) {
+            if ($criterion instanceof CriterionContract) {
+                $query = $criterion->apply($query, $repository);
+            } elseif ($criterion instanceof Closure) {
+                $query = $criterion($query, $repository);
+            }
+        }
+
+        return $query;
+    }
+}

--- a/tests/AbstractEloquentTests.php
+++ b/tests/AbstractEloquentTests.php
@@ -1,0 +1,147 @@
+<?php
+
+use Illuminate\Database\Capsule\Manager;
+use Illuminate\Database\Eloquent\Model;
+use Rinvex\Tests\Stubs\EloquentPost;
+use Rinvex\Tests\Stubs\EloquentPostRepository;
+use Rinvex\Tests\Stubs\EloquentUser;
+use Rinvex\Tests\Stubs\EloquentUserRepository;
+
+abstract class AbstractEloquentTests extends PHPUnit_Framework_TestCase
+{
+    use \Illuminate\Support\Traits\CapsuleManagerTrait;
+
+    /**
+     * @var \Illuminate\Container\Container
+     */
+    protected $container;
+
+    /**
+     * Setup the database schema.
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->setupContainer();
+        $this->setupDatabase(new Manager($this->getContainer()));
+        $this->migrate();
+        $this->seed();
+    }
+
+    /**
+     * Setup the IoC container instance.
+     */
+    protected function setupContainer()
+    {
+        $config = [
+            'models' => 'Models',
+            'cache'  => [
+                'keys_file' => '',
+                'lifetime'  => 0,
+                'clear_on'  => [
+                    'create',
+                    'update',
+                    'delete',
+                ],
+                'skip_uri' => 'skipCache',
+            ],
+        ];
+        $this->container = new \Illuminate\Container\Container();
+        $this->container->instance('config', new \Illuminate\Config\Repository());
+        $this->getContainer()['config']->offsetSet('rinvex.repository', $config);
+    }
+
+    protected function setupDatabase(Manager $db)
+    {
+        $db->addConnection([
+            'driver'    => 'sqlite',
+            'database'  => ':memory:',
+        ]);
+
+        $db->bootEloquent();
+        $db->setAsGlobal();
+    }
+
+    /**
+     * Create tables.
+     *
+     * @return void
+     */
+    protected function migrate()
+    {
+        $this->schema()->create('users', function ($table) {
+            $table->increments('id');
+            $table->string('name')->nullable();
+            $table->string('email');
+            $table->timestamps();
+        });
+
+        $this->schema()->create('posts', function ($table) {
+            $table->increments('id');
+            $table->integer('user_id');
+            $table->integer('parent_id')->nullable();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Create test users and posts.
+     */
+    protected function seed()
+    {
+        $evsign  = EloquentUser::create(['name' => 'evsign', 'email' => 'evsign.alex@gmail.com']);
+        $omranic = EloquentUser::create(['name' => 'omranic', 'email' => 'me@omranic.com']);
+
+        $evsign->posts()->saveMany([
+            new EloquentPost(['name' => 'first post']),
+            new EloquentPost(['name' => 'second post']),
+        ]);
+
+        $omranic->posts()->saveMany([
+            new EloquentPost(['name' => 'third post']),
+            new EloquentPost(['name' => 'fourth post']),
+        ]);
+    }
+
+    /**
+     * Get Schema Builder.
+     *
+     * @return \Illuminate\Database\Schema\Builder
+     */
+    protected function schema()
+    {
+        return Model::resolveConnection()->getSchemaBuilder();
+    }
+
+    /**
+     * Tear down the database schema.
+     *
+     * @return void
+     */
+    public function tearDown()
+    {
+        $this->schema()->drop('users');
+        $this->schema()->drop('posts');
+        unset($this->container);
+    }
+
+    /**
+     * @return EloquentUserRepository
+     */
+    protected function userRepository()
+    {
+        return (new EloquentUserRepository())
+            ->setContainer($this->getContainer());
+    }
+
+    /**
+     * @return EloquentPostRepository
+     */
+    protected function postRepository()
+    {
+        return (new EloquentPostRepository())
+            ->setContainer(new \Illuminate\Container\Container());
+    }
+}

--- a/tests/EloquentRepositoryCriteriaIntegrationTests.php
+++ b/tests/EloquentRepositoryCriteriaIntegrationTests.php
@@ -1,0 +1,99 @@
+<?php
+
+class EloquentRepositoryCriteriaIntegrationTests extends AbstractEloquentTests
+{
+    public function testFindAllByClassNameCriterion()
+    {
+        $userRepository = $this->userRepository();
+        $userRepository->pushCriterion(FirstTestCriterion::class);
+        $result = $userRepository->findAll();
+
+        $this->assertCount(1, $result);
+        $this->assertContainsOnlyInstancesOf(\Rinvex\Tests\Stubs\EloquentUser::class, $result);
+        $this->assertEquals($result->first()->id, 1);
+    }
+
+    public function testFindAllByObjectCriterion()
+    {
+        $userRepository = $this->userRepository();
+        $userRepository->pushCriterion(new FirstTestCriterion());
+        $result = $userRepository->findAll();
+
+        $this->assertCount(1, $result);
+        $this->assertContainsOnlyInstancesOf(\Rinvex\Tests\Stubs\EloquentUser::class, $result);
+        $this->assertEquals($result->first()->id, 1);
+    }
+
+    public function testFindAllByClosureCriterion()
+    {
+        $userRepository = $this->userRepository();
+        $userRepository->pushCriterion(function ($query, $repository) {
+            return $query->where('id', 2);
+        });
+        $result = $userRepository->findAll();
+
+        $this->assertCount(1, $result);
+        $this->assertContainsOnlyInstancesOf(\Rinvex\Tests\Stubs\EloquentUser::class, $result);
+        $this->assertEquals($result->first()->id, 2);
+    }
+
+    public function testFindAllWithDefaultCriteria()
+    {
+        $userRepository = $this->userRepository();
+        $userRepository->pushCriterion(function ($query, $repository) {
+            return $query->orWhere('id', 1);
+        })->setDefaultCriteria([new SecondTestCriterion()]);
+
+        $result = $userRepository->findAll();
+
+        $this->assertCount(2, $result);
+        $this->assertContainsOnlyInstancesOf(\Rinvex\Tests\Stubs\EloquentUser::class, $result);
+    }
+
+    public function testFindAllWithSkipCriteria()
+    {
+        $userRepository = $this->userRepository();
+
+        $userRepository->pushCriteria([
+            new FirstTestCriterion(),
+            new SecondTestCriterion(),
+        ]);
+
+        $result = $userRepository->skipCriteria()->findAll();
+
+        $this->assertCount(2, $result);
+        $this->assertContainsOnlyInstancesOf(\Rinvex\Tests\Stubs\EloquentUser::class, $result);
+    }
+
+    public function testFindAllAfterRemoveSkipCriteria()
+    {
+        $userRepository = $this->userRepository();
+
+        $userRepository->pushCriteria([
+            new FirstTestCriterion(),
+        ]);
+
+        $result = $userRepository->skipCriteria()->findAll();
+
+        $this->assertCount(2, $result);
+        $this->assertContainsOnlyInstancesOf(\Rinvex\Tests\Stubs\EloquentUser::class, $result);
+
+        $result = $userRepository->skipCriteria(false)->findAll();
+        $this->assertCount(1, $result);
+        $this->assertContainsOnlyInstancesOf(\Rinvex\Tests\Stubs\EloquentUser::class, $result);
+    }
+
+    public function testFindAllWithSkipDefaultCriteria()
+    {
+        $userRepository = $this->userRepository();
+
+        $userRepository->pushCriteria([
+            new FirstTestCriterion(),
+        ])->setDefaultCriteria([new SecondTestCriterion()]);
+
+        $result = $userRepository->skipDefaultCriteria()->findAll();
+
+        $this->assertCount(1, $result);
+        $this->assertContainsOnlyInstancesOf(\Rinvex\Tests\Stubs\EloquentUser::class, $result);
+    }
+}

--- a/tests/EloquentRepositoryCriteriaTests.php
+++ b/tests/EloquentRepositoryCriteriaTests.php
@@ -1,0 +1,506 @@
+<?php
+
+class EloquentRepositoryCriteriaTests extends AbstractEloquentTests
+{
+    public function testObjectCriterionPush()
+    {
+        $userRepository = $this->userRepository();
+        $criterion      = new FirstTestCriterion();
+        $userRepository->pushCriterion($criterion);
+
+        $this->assertAttributeCount(1, 'criteria', $userRepository);
+        $this->assertAttributeContains($criterion, 'criteria', $userRepository);
+    }
+
+    public function testClosureCriterionPush()
+    {
+        $userRepository = $this->userRepository();
+        $criterion      = function ($query, $repository) {
+            return $query->where('id', 1);
+        };
+
+        $userRepository->pushCriterion($criterion);
+
+        $this->assertAttributeCount(1, 'criteria', $userRepository);
+        $this->assertAttributeContains($criterion, 'criteria', $userRepository);
+    }
+
+    public function testClassNameCriterionPush()
+    {
+        $userRepository = $this->userRepository();
+        $criterion      = FirstTestCriterion::class;
+        $userRepository->pushCriterion($criterion);
+
+        $this->assertAttributeCount(1, 'criteria', $userRepository);
+        $this->assertContainsOnlyInstancesOf($criterion, $this->getObjectAttribute($userRepository, 'criteria'));
+    }
+
+    public function testClassNameWithAssocArgumentsAssocCriterionPush()
+    {
+        $userRepository = $this->userRepository();
+        $userRepository->pushCriterion([ThirdTestWithArgumentsCriterion::class => ['to' => '2016-09-30', 'from' => '2016-09-01']]);
+
+        $this->assertAttributeCount(1, 'criteria', $userRepository);
+        $this->assertArrayHasKey(ThirdTestWithArgumentsCriterion::class, $userRepository->getCriteria());
+
+        $criterion = $userRepository->getCriterion(ThirdTestWithArgumentsCriterion::class);
+        $this->assertAttributeEquals('2016-09-01', 'from', $criterion);
+        $this->assertAttributeEquals('2016-09-30', 'to', $criterion);
+    }
+
+    public function testClassNameWithAssocArgumentsSequentialCriterionPush()
+    {
+        $userRepository = $this->userRepository();
+        $userRepository->pushCriterion([ThirdTestWithArgumentsCriterion::class, ['to' => '2016-09-30', 'from' => '2016-09-01']]);
+
+        $this->assertAttributeCount(1, 'criteria', $userRepository);
+        $this->assertArrayHasKey(ThirdTestWithArgumentsCriterion::class, $userRepository->getCriteria());
+
+        $criterion = $userRepository->getCriterion(ThirdTestWithArgumentsCriterion::class);
+        $this->assertAttributeEquals('2016-09-01', 'from', $criterion);
+        $this->assertAttributeEquals('2016-09-30', 'to', $criterion);
+    }
+
+    public function testClassNameWithSequentialArgumentsAssocCriterionPush()
+    {
+        $userRepository = $this->userRepository();
+        $userRepository->pushCriterion([ThirdTestWithArgumentsCriterion::class => ['2016-09-01', '2016-09-30']]);
+
+        $this->assertAttributeCount(1, 'criteria', $userRepository);
+        $this->assertArrayHasKey(ThirdTestWithArgumentsCriterion::class, $userRepository->getCriteria());
+
+        $criterion = $userRepository->getCriterion(ThirdTestWithArgumentsCriterion::class);
+        $this->assertAttributeEquals('2016-09-01', 'from', $criterion);
+        $this->assertAttributeEquals('2016-09-30', 'to', $criterion);
+    }
+
+    public function testClassNameWithSequentialArgumentsSequentialCriterionPush()
+    {
+        $userRepository = $this->userRepository();
+        $userRepository->pushCriterion([ThirdTestWithArgumentsCriterion::class, ['2016-09-01', '2016-09-30']]);
+
+        $this->assertAttributeCount(1, 'criteria', $userRepository);
+        $this->assertArrayHasKey(ThirdTestWithArgumentsCriterion::class, $userRepository->getCriteria());
+
+        $criterion = $userRepository->getCriterion(ThirdTestWithArgumentsCriterion::class);
+        $this->assertAttributeEquals('2016-09-01', 'from', $criterion);
+        $this->assertAttributeEquals('2016-09-30', 'to', $criterion);
+    }
+
+    public function testPushTwoDifferentCriteria()
+    {
+        $userRepository  = $this->userRepository();
+        $firstCriterion  = FirstTestCriterion::class;
+        $secondCriterion = SecondTestCriterion::class;
+
+        $userRepository->pushCriterion([$firstCriterion]);
+        $userRepository->pushCriterion([$secondCriterion]);
+
+        $this->assertAttributeCount(2, 'criteria', $userRepository);
+    }
+
+    public function testPushTwoDifferentClosureCriteria()
+    {
+        $userRepository = $this->userRepository();
+        $firstCriterion = function ($query, $repository) {
+            return $query->where('id', 1);
+        };
+        $secondCriterion = function ($query, $repository) {
+            return $query->where('id', 2);
+        };
+
+        $userRepository->pushCriterion($firstCriterion);
+        $userRepository->pushCriterion($secondCriterion);
+
+        $this->assertAttributeCount(2, 'criteria', $userRepository);
+    }
+
+    public function testPushTwoSimilarCriteria()
+    {
+        $userRepository = $this->userRepository();
+        $firstCriterion = FirstTestCriterion::class;
+
+        $userRepository->pushCriterion($firstCriterion);
+        $userRepository->pushCriterion($firstCriterion);
+
+        $this->assertAttributeCount(1, 'criteria', $userRepository);
+    }
+
+    public function testPushCriteria()
+    {
+        $userRepository = $this->userRepository();
+
+        $firstCriterion  = FirstTestCriterion::class;
+        $secondCriterion = new SecondTestCriterion();
+        $thirdCriterion  = function ($query, $repository) {
+            return $query->where('id', 1);
+        };
+
+        $userRepository->pushCriteria([
+            $firstCriterion,
+            $secondCriterion,
+            $thirdCriterion,
+        ]);
+
+        $this->assertAttributeCount(3, 'criteria', $userRepository);
+    }
+
+    public function testRemoveCriterionWhenPushedByClassName()
+    {
+        $userRepository  = $this->userRepository();
+        $firstCriterion  = FirstTestCriterion::class;
+        $secondCriterion = SecondTestCriterion::class;
+
+        $userRepository->pushCriterion($firstCriterion);
+        $this->assertAttributeCount(1, 'criteria', $userRepository);
+
+        $userRepository->removeCriterion($firstCriterion);
+        $this->assertAttributeCount(0, 'criteria', $userRepository);
+
+        $userRepository->pushCriterion($firstCriterion);
+        $userRepository->pushCriterion($secondCriterion);
+        $this->assertAttributeCount(2, 'criteria', $userRepository);
+
+        $userRepository->removeCriterion($firstCriterion);
+        $this->assertAttributeCount(1, 'criteria', $userRepository);
+        $userRepository->removeCriterion($firstCriterion);
+        $this->assertAttributeCount(1, 'criteria', $userRepository);
+        $userRepository->removeCriterion($secondCriterion);
+        $this->assertAttributeCount(0, 'criteria', $userRepository);
+    }
+
+    public function testRemoveCriterionWhenPushedObject()
+    {
+        $userRepository  = $this->userRepository();
+        $firstCriterion  = new FirstTestCriterion();
+        $secondCriterion = new SecondTestCriterion();
+
+        $userRepository->pushCriterion($firstCriterion);
+        $this->assertAttributeCount(1, 'criteria', $userRepository);
+
+        $userRepository->removeCriterion($firstCriterion);
+        $this->assertAttributeCount(0, 'criteria', $userRepository);
+
+        $userRepository->pushCriterion($firstCriterion);
+        $userRepository->pushCriterion($secondCriterion);
+        $this->assertAttributeCount(2, 'criteria', $userRepository);
+
+        $userRepository->removeCriterion($firstCriterion);
+        $this->assertAttributeCount(1, 'criteria', $userRepository);
+        $userRepository->removeCriterion($firstCriterion);
+        $this->assertAttributeCount(1, 'criteria', $userRepository);
+        $userRepository->removeCriterion($secondCriterion);
+        $this->assertAttributeCount(0, 'criteria', $userRepository);
+
+        $userRepository->pushCriterion($firstCriterion);
+        $userRepository->removeCriterion(FirstTestCriterion::class);
+        $this->assertAttributeCount(0, 'criteria', $userRepository);
+    }
+
+    public function testRemoveCriterionWhenPushedClosures()
+    {
+        $userRepository = $this->userRepository();
+        $firstCriterion = function ($query, $repository) {
+            return $query->where('id', 1);
+        };
+
+        $secondCriterion = function ($query, $repository) {
+            return $query->where('id', 2);
+        };
+
+        $userRepository->pushCriterion($firstCriterion);
+        $this->assertAttributeCount(1, 'criteria', $userRepository);
+
+        $userRepository->removeCriterion($firstCriterion);
+        $this->assertAttributeCount(0, 'criteria', $userRepository);
+
+        $userRepository->pushCriterion($firstCriterion);
+        $userRepository->pushCriterion($secondCriterion);
+        $this->assertAttributeCount(2, 'criteria', $userRepository);
+
+        $userRepository->removeCriterion($firstCriterion);
+        $this->assertAttributeCount(1, 'criteria', $userRepository);
+        $userRepository->removeCriterion($firstCriterion);
+        $this->assertAttributeCount(1, 'criteria', $userRepository);
+        $userRepository->removeCriterion($secondCriterion);
+        $this->assertAttributeCount(0, 'criteria', $userRepository);
+    }
+
+    public function testRemoveCriteria()
+    {
+        $userRepository = $this->userRepository();
+        $firstCriterion = function ($query, $repository) {
+            return $query->where('id', 1);
+        };
+
+        $secondCriterion = function ($query, $repository) {
+            return $query->where('id', 2);
+        };
+
+        $userRepository->pushCriterion($firstCriterion);
+        $userRepository->pushCriterion($secondCriterion);
+        $this->assertAttributeCount(2, 'criteria', $userRepository);
+
+        $userRepository->removeCriteria([$firstCriterion, $secondCriterion]);
+        $this->assertAttributeCount(0, 'criteria', $userRepository);
+
+        $userRepository->pushCriterion($firstCriterion);
+        $userRepository->pushCriterion($secondCriterion);
+        $userRepository->removeCriteria([$firstCriterion]);
+        $userRepository->removeCriteria([$secondCriterion]);
+        $this->assertAttributeCount(0, 'criteria', $userRepository);
+    }
+
+    public function testFlushCriteria()
+    {
+        $userRepository = $this->userRepository();
+
+        $userRepository->pushCriteria([
+            new FirstTestCriterion(),
+            new SecondTestCriterion(),
+        ]);
+
+        $this->assertAttributeCount(2, 'criteria', $userRepository);
+        $userRepository->flushCriteria();
+        $this->assertAttributeCount(0, 'criteria', $userRepository);
+    }
+
+    public function testSetDefaultCriteria()
+    {
+        $userRepository = $this->userRepository();
+
+        $userRepository->setDefaultCriteria([
+            new FirstTestCriterion(),
+            new SecondTestCriterion(),
+        ]);
+
+        $this->assertAttributeCount(2, 'defaultCriteria', $userRepository);
+    }
+
+    public function testGetDefaultCriteria()
+    {
+        $userRepository = $this->userRepository();
+        $criteria       = [
+            new FirstTestCriterion(),
+            new SecondTestCriterion(),
+        ];
+
+        $userRepository->setDefaultCriteria($criteria);
+        $defaultCriteria = $userRepository->getDefaultCriteria();
+
+        $this->assertArrayHasKey(FirstTestCriterion::class, $defaultCriteria);
+        $this->assertArrayHasKey(SecondTestCriterion::class, $defaultCriteria);
+    }
+
+    public function testGetCriteria()
+    {
+        $userRepository = $this->userRepository();
+        $criteria       = [
+            new FirstTestCriterion(),
+            new SecondTestCriterion(),
+        ];
+
+        $userRepository->pushCriteria($criteria);
+
+        $this->assertArrayHasKey(FirstTestCriterion::class, $userRepository->getCriteria());
+        $this->assertArrayHasKey(SecondTestCriterion::class, $userRepository->getCriteria());
+    }
+
+    public function testGetCriteriaWithDefault()
+    {
+        $userRepository = $this->userRepository();
+
+        $criteria = [
+            new FirstTestCriterion(),
+            new SecondTestCriterion(),
+        ];
+
+        $defaultCriteria = [
+            function ($query, $repository) {
+                return $query->where('id', 1);
+            },
+        ];
+
+        $userRepository->setDefaultCriteria($defaultCriteria)->pushCriteria($criteria);
+
+        $this->assertCount(3, $userRepository->getCriteria());
+    }
+
+    public function testGetCriteriaWithSkipCriteria()
+    {
+        $userRepository = $this->userRepository();
+
+        $criteria = [
+            new FirstTestCriterion(),
+            new SecondTestCriterion(),
+        ];
+
+        $userRepository->pushCriteria($criteria)->skipCriteria();
+
+        $this->assertAttributeEquals(true, 'skipCriteria', $userRepository);
+        $this->assertEmpty($userRepository->getCriteria());
+    }
+
+    public function testGetCriteriaWithDefaultWithSkipCriteria()
+    {
+        $userRepository = $this->userRepository();
+
+        $criteria = [
+            new FirstTestCriterion(),
+            new SecondTestCriterion(),
+        ];
+        $defaultCriteria = [
+            function ($query, $repository) {
+                return $query->where('id', 1);
+            },
+        ];
+
+        $userRepository->setDefaultCriteria($defaultCriteria)->pushCriteria($criteria)->skipCriteria();
+
+        $this->assertAttributeEquals(true, 'skipCriteria', $userRepository);
+        $this->assertEmpty($userRepository->getCriteria());
+    }
+
+    public function testGetCriteriaWithSkipDefaultCriteria()
+    {
+        $userRepository = $this->userRepository();
+
+        $criteria = [
+            new FirstTestCriterion(),
+            new SecondTestCriterion(),
+        ];
+        $defaultCriteria = [
+            function ($query, $repository) {
+                return $query->where('id', 1);
+            },
+        ];
+
+        $userRepository->setDefaultCriteria($defaultCriteria)->pushCriteria($criteria)->skipDefaultCriteria();
+        $this->assertAttributeEquals(true, 'skipDefaultCriteria', $userRepository);
+        $this->assertCount(2, $userRepository->getCriteria());
+    }
+
+    public function testHasCriterion()
+    {
+        $userRepository = $this->userRepository();
+
+        $criteria = [
+            new FirstTestCriterion(),
+            new SecondTestCriterion(),
+        ];
+
+        $userRepository->pushCriteria($criteria);
+
+        $this->assertTrue($userRepository->hasCriterion(FirstTestCriterion::class));
+        $this->assertTrue($userRepository->hasCriterion(SecondTestCriterion::class));
+    }
+
+    public function testHasCriterionByClosure()
+    {
+        $userRepository = $this->userRepository();
+        $firstCriteria  = function ($query, $repository) {
+            return $query->where('id', 1);
+        };
+
+        $secondCriteria = function ($query, $repository) {
+            return $query->where('id', 2);
+        };
+
+        $userRepository->pushCriteria([$firstCriteria, $secondCriteria]);
+
+        $this->assertTrue($userRepository->hasCriterion($firstCriteria));
+        $this->assertTrue($userRepository->hasCriterion($secondCriteria));
+    }
+
+    public function testGetCriterion()
+    {
+        $userRepository = $this->userRepository();
+        $userRepository->pushCriteria([
+            FirstTestCriterion::class,
+            SecondTestCriterion::class,
+        ]);
+
+        $this->assertInstanceOf(FirstTestCriterion::class, $userRepository->getCriterion(FirstTestCriterion::class));
+        $this->assertInstanceOf(SecondTestCriterion::class, $userRepository->getCriterion(SecondTestCriterion::class));
+    }
+
+    public function testGetCriterionByClosure()
+    {
+        $userRepository = $this->userRepository();
+        $firstCriteria  = function ($query, $repository) {
+            return $query->where('id', 1);
+        };
+
+        $secondCriteria = function ($query, $repository) {
+            return $query->where('id', 2);
+        };
+
+        $userRepository->pushCriteria([$firstCriteria, $secondCriteria]);
+        $this->assertSame($firstCriteria, $userRepository->getCriterion($firstCriteria));
+        $this->assertSame($secondCriteria, $userRepository->getCriterion($secondCriteria));
+        $this->assertNotSame($secondCriteria, $userRepository->getCriterion($firstCriteria));
+    }
+
+    public function testApplyCriteria()
+    {
+        $userRepository = $this->userRepository();
+        $userRepository->pushCriteria([
+            new FirstTestCriterion(),
+            new SecondTestCriterion(),
+        ]);
+
+        $resultQuery = $userRepository->applyCriteria($userRepository->createModel(), $userRepository);
+
+        $this->assertEquals('select * from "users" where "id" = ? and "id" = ?', $resultQuery->toSql());
+        $this->assertEquals([0 => 1, 1 => 2], $resultQuery->getBindings());
+    }
+
+    public function testApplyCriteriaWithClosureCriteria()
+    {
+        $userRepository = $this->userRepository();
+        $userRepository->pushCriteria([
+            new FirstTestCriterion(),
+            new SecondTestCriterion(),
+        ])->pushCriterion(function ($query, $repository) {
+            return $query->where('id', 3);
+        });
+
+        $resultQuery = $userRepository->applyCriteria($userRepository->createModel(), $userRepository);
+
+        $this->assertEquals('select * from "users" where "id" = ? and "id" = ? and "id" = ?', $resultQuery->toSql());
+        $this->assertEquals([0 => 1, 1 => 2, 2 => 3], $resultQuery->getBindings());
+    }
+}
+
+class FirstTestCriterion implements \Rinvex\Repository\Contracts\CriterionContract
+{
+    public function apply($query, $repository)
+    {
+        return $query->where('id', 1);
+    }
+}
+
+class SecondTestCriterion implements \Rinvex\Repository\Contracts\CriterionContract
+{
+    public function apply($query, $repository)
+    {
+        return $query->where('id', 2);
+    }
+}
+
+class ThirdTestWithArgumentsCriterion implements \Rinvex\Repository\Contracts\CriterionContract
+{
+    protected $from;
+    protected $to;
+
+    public function __construct($from, $to)
+    {
+        $this->from = $from;
+        $this->to   = $to;
+    }
+
+    public function apply($query, $repository)
+    {
+        return $query->whereBetween('created_at', [$this->from, $this->to]);
+    }
+}

--- a/tests/EloquentRepositoryTests.php
+++ b/tests/EloquentRepositoryTests.php
@@ -1,0 +1,56 @@
+<?php
+
+class EloquentRepositoryTests extends \AbstractEloquentTests
+{
+    public function testFindAll()
+    {
+        $userRepository = $this->userRepository();
+        $result         = $userRepository->findAll();
+        $this->assertCount(2, $result);
+        $this->assertContainsOnlyInstancesOf(\Rinvex\Tests\Stubs\EloquentUser::class, $result);
+    }
+
+    public function testFind()
+    {
+        $userRepository = $this->userRepository();
+        $result         = $userRepository->find(1);
+        $this->assertInstanceOf(\Rinvex\Tests\Stubs\EloquentUser::class, $result);
+        $this->assertEquals(1, $result->id);
+    }
+
+    public function testFindBy()
+    {
+        $userRepository = $this->userRepository();
+        $result         = $userRepository->findBy('name', 'evsign');
+        $this->assertInstanceOf(\Rinvex\Tests\Stubs\EloquentUser::class, $result);
+        $this->assertEquals('evsign', $result->name);
+    }
+
+    public function testFindFirst()
+    {
+        $userRepository = $this->userRepository();
+        $result         = $userRepository->findFirst();
+        $this->assertInstanceOf(\Rinvex\Tests\Stubs\EloquentUser::class, $result);
+        $this->assertEquals(1, $result->id);
+    }
+
+    public function testFindWhere()
+    {
+        $userRepository = $this->userRepository();
+        $result         = $userRepository->findWhere(['name', '=', 'omranic']);
+        $this->assertCount(1, $result);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $result);
+        $this->assertContainsOnlyInstancesOf(\Rinvex\Tests\Stubs\EloquentUser::class, $result);
+        $this->assertEquals('omranic', $result->first()->name);
+    }
+
+    public function testFindWhereIn()
+    {
+        $userRepository = $this->userRepository();
+        $result         = $userRepository->findWhereIn(['name', ['omranic', 'evsign']]);
+        $this->assertCount(2, $result);
+        $this->assertInstanceOf(\Illuminate\Database\Eloquent\Collection::class, $result);
+        $this->assertContainsOnlyInstancesOf(\Rinvex\Tests\Stubs\EloquentUser::class, $result);
+        $this->assertEquals(['evsign', 'omranic'], $result->pluck('name')->toArray());
+    }
+}

--- a/tests/Stubs/EloquentPost.php
+++ b/tests/Stubs/EloquentPost.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rinvex\Tests\Stubs;
+
+class EloquentPost extends \Illuminate\Database\Eloquent\Model
+{
+    protected $table    = 'posts';
+    protected $fillable = ['user_id', 'parent_id', 'name'];
+
+    public function user()
+    {
+        $this->belongsTo(EloquentUser::class);
+    }
+}

--- a/tests/Stubs/EloquentPostRepository.php
+++ b/tests/Stubs/EloquentPostRepository.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Rinvex\Tests\Stubs;
+
+use Rinvex\Repository\Repositories\EloquentRepository;
+
+class EloquentPostRepository extends EloquentRepository
+{
+    protected $model        = EloquentPost::class;
+    protected $repositoryId = 'rinvex.repository.post';
+}

--- a/tests/Stubs/EloquentUser.php
+++ b/tests/Stubs/EloquentUser.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rinvex\Tests\Stubs;
+
+class EloquentUser extends \Illuminate\Database\Eloquent\Model
+{
+    protected $table    = 'users';
+    protected $fillable = ['name', 'email'];
+
+    public function posts()
+    {
+        return $this->hasMany(EloquentPost::class, 'user_id');
+    }
+}

--- a/tests/Stubs/EloquentUserRepository.php
+++ b/tests/Stubs/EloquentUserRepository.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Rinvex\Tests\Stubs;
+
+use Rinvex\Repository\Repositories\EloquentRepository;
+use Rinvex\Repository\Traits\Criteriable;
+
+class EloquentUserRepository extends EloquentRepository
+{
+    use Criteriable;
+
+    protected $model        = EloquentUser::class;
+    protected $repositoryId = 'rinvex.repository.user';
+}


### PR DESCRIPTION
Promised pull request)
I was very wondered there is no tests and with this pr fix some of that) I cover all my criteria code and `findAll` method in `EloquentRepository`. In future i want to cover all and hope somebody help with it)

And maybe somebody can write documentation for this, because i afraid my poor english does a bad job.

How to use:
At first add `Rinvex\Repository\Traits\Criteriable` trait in your repository. 
```php
use Rinvex\Repository\Repositories\EloquentRepository;
use Rinvex\Repository\Traits\Criteriable;

class UserRepository extends EloquentRepository
{
    use Criteriable;

    protected $model = User::class;
    protected $repositoryId = 'rinvex.repository.user';
}
```
After that you can `pushCriteria` or `pushCriterion` to your repository. Criteria can be implemented as separeted classes which must implement `Rinvex\Repository\Contracts\CriterionContract` with one method `apply($query, $reposiroty)`. Criterion can be pushed by class name, like instantiated object or closure which must have same signature like `apply` method in `CriterionContract`.
```php
$repository->pushCriteria([new RangeCriterion, new CheckCriterion]);
$repository->pushCriteria([RangeCriterion::class, CheckCriterion::class]);
$repository->pushCriteria([new RangeCriterion, function ($query, $repository) { return $query->where('id', 1); }]);
$repository->pushCriterion(function ($query, $repository) { return $query->where('id', 1); });
```
Applying occurs during execution `prepareQuery` method in `BaseRepository`.

If you want perform query without pushed criteria you can use `$repository->skipCriteria()->findAll()` method. Also you can add  and skip by analogy default criteria. `$repository->setDefaultCriteria([])->skipDefaultCriteria()`

Also there is some helpers methods for checking and getting criteria.
```php
$repository->hasCriterion(RangeCriterion::class); //check for existanse of given criterion in current criteria list
$repository->getCriterion(RangeCriterion::class); //return criterion object from criteria list
$repository->removeCriterion(RangeCriterion::class); //remove criterion of this clas from current criteria list
```

Some notes about closure criteria. If you pass in arguments closure criterion declaration, there is no way to remove or check for this creterion existence. This is normal and describing this behavior is beyond of this message)

Also you can use this trait in anything places where you want to implement criteriable behavior.
For example you can use it in eloquent model, but you must find the way to apply criteria.
```php
use Illuminate\Database\Eloquent\Model;
use Rinvex\Repository\Traits\Criteriable;

class User extends Model
{
    use Criteriable;

    public function scopeCriteriable($query)
    {
        return $this->applyCriteria($query, $this);
    }
}

$user = new User;
$user->pushCriterion(RangeCriterion::class);
$user->criteriable()->get();
```
#60 