### PR TITLE
whereHas callback default null

### DIFF
--- a/src/Contracts/RepositoryContract.php
+++ b/src/Contracts/RepositoryContract.php
@@ -149,7 +149,7 @@ interface RepositoryContract
      *
      * @return $this
      */
-    public function whereHas($relation, Closure $callback, $operator = '>=', $count = 1);
+    public function whereHas($relation, Closure $callback = null, $operator = '>=', $count = 1);
 
     /**
      * Set the "offset" value of the query.

--- a/src/Repositories/BaseRepository.php
+++ b/src/Repositories/BaseRepository.php
@@ -381,7 +381,7 @@ abstract class BaseRepository implements RepositoryContract, CacheableContract
     /**
      * {@inheritdoc}
      */
-    public function whereHas($relation, Closure $callback, $operator = '>=', $count = 1)
+    public function whereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
     {
         // The last `$operator` & `$count` expressions are intentional to fix list() & array_pad() results
         $this->whereHas[] = [$relation, $callback, $operator ?: '>=', $count ?: 1];


### PR DESCRIPTION
callback can be null
$repository->whereHas('users');
$repository->whereHas('users', null, '<');
